### PR TITLE
Do not busy-wait

### DIFF
--- a/R/status.R
+++ b/R/status.R
@@ -50,6 +50,7 @@ my_curl_stream <- function(url, callback, bufsize = 80) {
   }
   while (length(buf <- readBin(con, raw(), bufsize))) {
     callback(buf)
+    Sys.sleep(1)
   }
   cat("\r                                                 \r")
 }


### PR DESCRIPTION
Previous behavior kept R pegged at 100% usage while the request was being performed. This simply sleeps in the loop. We could use a different sleep time, but 1 second seems ok for this use I think.