### PR TITLE
Explicitly specify units for `as.numeric.difftime`

### DIFF
--- a/R/print-status.R
+++ b/R/print-status.R
@@ -18,7 +18,7 @@ check_print2 <- function(x) {
 
   greyish <- make_style("darkgrey")
 
-  submitted_time <- as.numeric(Sys.time() - parse_iso_8601(x$submitted))
+  submitted_time <- as.numeric(units = "secs", Sys.time() - parse_iso_8601(x$submitted))
   submitted <- if (submitted_time > 0) {
     paste(pretty_ms(submitted_time * 1000), "ago")
   } else {


### PR DESCRIPTION
Previously if the time was over a minute the default unit of auto would
convert the value to a decimal minute and you would get a display of
1.5s rather than 1m 30s.