### PR TITLE
units arg has to be after the 'x' arg

### DIFF
--- a/R/print-status.R
+++ b/R/print-status.R
@@ -18,7 +18,7 @@ check_print2 <- function(x) {
 
   greyish <- make_style("darkgrey")
 
-  submitted_time <- as.numeric(units = "secs", Sys.time() - parse_iso_8601(x$submitted))
+  submitted_time <- as.numeric(Sys.time() - parse_iso_8601(x$submitted), units = "secs")
   submitted <- if (submitted_time > 0) {
     paste(pretty_ms(submitted_time * 1000), "ago")
   } else {


### PR DESCRIPTION
For some reason on my machine, this fails to work.  By switching the order, the units work as expected.

Fix for #94 

```r
as.numeric(units = "secs", Sys.time() - parsedate::parse_iso_8601("2018-04-19"))
# Error in as.numeric(units = "secs", Sys.time() - parsedate::parse_iso_8601("2018-04-19")) : 
#   supplied argument name 'units' does not match 'x'
as.numeric(Sys.time() - parsedate::parse_iso_8601("2018-04-19"), units = "secs")
# [1] 71099.63
```