### PR TITLE
After check_for_cran print summary of systems

### DIFF
--- a/R/check-class.R
+++ b/R/check-class.R
@@ -67,6 +67,9 @@ rhub_check <- R6Class(
 
     print = function(...)
       check_print(self, private, ...),
+    
+    print_system = function(...)
+      check_print_system(self, private, ...),
 
     web = function(which = NULL)
       check_web(self, private, which),

--- a/R/print-platforms.R
+++ b/R/print-platforms.R
@@ -1,0 +1,17 @@
+
+check_print_system <- function(self, private, ...) {
+  if (is.null(private$status_)) {
+    cat("Updating status...\n")
+    self$update()
+  }
+  for (x in private$status_) check_print_system2(x)
+  invisible(self)
+}
+
+
+check_print_system2 <- function(x) {
+
+  cat("- ", x$platform$description, "\n")
+  
+  invisible(x)
+}


### PR DESCRIPTION
To address #77 

There's probably a lot of things missing from this implementation but here's what I can get.

``` r
mychecks <- rhub::list_my_checks(howmany = 3)
mychecks$print_system()
#>   -  Fedora Linux, R-devel, clang, gfortran 
#>   -  Ubuntu Linux 16.04 LTS, R-release, GCC 
#>   -  Windows Server 2008 R2 SP1, R-devel, 32/64 bit
```

<sup>Created on 2019-01-30 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>
