### PR TITLE
cli::col_* functions appeared in cli 1.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Roxygen: list(markdown = TRUE)
 Imports:
     assertthat,
     callr,
-    cli,
+    cli (>= 1.1.0),
     crayon,
     desc,
     digest,


### PR DESCRIPTION
Otherwise installing rhub fails with:

```
[...]
* installing *source* package ‘rhub’ ...
** package ‘rhub’ successfully unpacked and MD5 sums checked
** R
** inst
** byte-compile and prepare package for lazy loading
Error : object ‘col_blue’ is not exported by 'namespace:cli'
ERROR: lazy loading failed for package ‘rhub’
[...]
```