### PR TITLE
fix bug in cran_summary()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 
 ## Bug fixes
 
-* `cran_summary()` now works even if there is a NOTE/WARNING/ERROR in one platform and nothing on other platforms.
+* `cran_summary()` now works even if there is a NOTE/WARNING/ERROR in one platform and nothing on other platforms (@fabian-s, #259).
 
 # rhub 1.1.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,10 @@
 
 # dev
 
+## Bug fixes
+
+* `cran_summary()` now works even if there is a NOTE/WARNING/ERROR in one platform and nothing on other platforms.
+
 # rhub 1.1.1
 
 ## Enhancements

--- a/R/check-class.R
+++ b/R/check-class.R
@@ -248,6 +248,7 @@ check_cran_summary <- function(self, private) {
 
   result <- do.call("rbind",
                     lapply(x, rectangle_status))
+  
   systems <- paste0("- R-hub ",
                     vapply(x, function(xx) xx$platform$name, ""),
                     " (",
@@ -255,7 +256,10 @@ check_cran_summary <- function(self, private) {
                     ")")
   lines <- paste0(systems, "\n")
 
-  if ("hash" %in% names(result)){
+  
+  result <- result[!is.na(result$type),]
+  
+  if (nrow(result) > 0){
     message("For a CRAN submission we recommend that you fix all NOTEs, WARNINGs and ERRORs.")
     unique_results <- unique(result[, c("type", "hash")])
     
@@ -326,7 +330,10 @@ rectangle_status <- function(x){
   df <- df[df$message != "",]
   
   if(nrow(df) == 0){
-    df <- data.frame(package = x$package)
+    df <- data.frame(package = x$package,
+                     type = NA,
+                     message = NA, 
+                     hash = NA)
   } else{
     df$hash <- hash_check(df$message)
   }


### PR DESCRIPTION
cf #259 

@fabian-s if you install `rhub` from this branch, does this solve the problem for you too?

```r
remotes::install_github("r-hub/rhub", ref = "cransummarybug")
rhub::list_package_checks() # inside the folder of your package
# look at group ID of the CRAN group
rhub::get_check(ID)$cran_summary()
```

For me it gives (the last check I sent to R-hub was a `rhub::check_for_cran()` of your package)

``` r
rhub::list_my_checks(howmany = 1)$group[1] -> id
rhub::get_check(id)$cran_summary()
#> For a CRAN submission we recommend that you fix all NOTEs, WARNINGs and ERRORs.
#> ## Test environments
#> - R-hub fedora-clang-devel (r-devel)
#> - R-hub linux-x86_64-rocker-gcc-san (r-devel)
#> - R-hub ubuntu-gcc-release (r-release)
#> - R-hub windows-x86_64-devel (r-devel)
#> 
#> ## R CMD check results
#> ❯ On ubuntu-gcc-release (r-release)
#>   checking compilation flags used ... WARNING
#>   Compilation used the following non-portable flag(s):
#>     ‘-Wdate-time’ ‘-Werror=format-security’ ‘-Wformat’
#> 
#> ❯ On fedora-clang-devel (r-devel), ubuntu-gcc-release (r-release), windows-x86_64-devel (r-devel)
#>   checking package dependencies ... NOTE
#>   Packages which this enhances but not available for checking:
#>     'SemiPar', 'lmerTest'
#> 
#> 0 errors ✔ | 1 warning ✖ | 1 note ✖
```

<sup>Created on 2019-04-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>