### PR TITLE
work on exposing results

### DIFF
--- a/man/get_check.Rd
+++ b/man/get_check.Rd
@@ -28,6 +28,7 @@ chk$update()
 chk$browse()
 chk$cran_summary()
 chk$urls()
+chk$results_df()
 }
 }
 

--- a/man/rhub_check.Rd
+++ b/man/rhub_check.Rd
@@ -14,6 +14,7 @@ ch$browse(which = NULL)
 ch$urls(which = NULL)
 ch$livelog(which = 1)
 ch$cran_summary()
+ch$results_df()
 }
 }
 
@@ -51,6 +52,11 @@ the check(s) is unknown.
 
 \code{ch$cran_summary()} prints text to be copy-pasted in cran-comments.md,
 it is especially useful on the output of \code{\link[=check_for_cran]{check_for_cran()}}.
+
+\code{ch$results_df()} returns a \code{data.frame} of check results (package,
+version, submitted, platform, and message+hash+type for any NOTE,
+WARNING or ERROR. If there's none of these, the \code{data.frame} has
+a single line with message, hash and type equal to NA.
 
 \code{ch$browse()} opens a tab or window in the default web browser, that points
 to the detailed logs of the check(s).


### PR DESCRIPTION
cf #257 cc @jozefhajnala, your feedback is very much welcome!
Note that the output for the check without any NOTE, WARNING and ERROR will change after #261 is merged.
Also note that there will be an error if any of the check had a build failure/preperror etc, not sure it's the best behaviour?

Here's what I got so far, only by recycling functions we had added for `cran_summary()`.

``` r
rhub::list_my_checks(howmany = 20)
#> # A tibble: 51 x 13
#>    package version result group   id      platform_name build_time
#>    <chr>   <chr>   <rhub> <rhub:> <rhub:> <chr>         <time>    
#>  1 RLRsim  3.1-5   N      3be32c1 0f66d50 fedora-clang… ~7m       
#>  2 RLRsim  3.1-5   ok     3be32c1 1cbb7ff linux-x86_64… ~14m      
#>  3 RLRsim  3.1-5   WN     3be32c1 7808ddd ubuntu-gcc-r… ~5m       
#>  4 RLRsim  3.1-5   N      3be32c1 f8a140e windows-x86_… ~3m       
#>  5 cranlo… 2.1.1.… N      4319312 056ec0c windows-x86_… ~2m       
#>  6 cranlo… 2.1.1.… N      4319312 3fa22f8 fedora-clang… ~3m       
#>  7 cranlo… 2.1.1.… N      4319312 e97b135 ubuntu-gcc-r… ~2m       
#>  8 note    1.0     NN     117dcf5 3c302fc ubuntu-gcc-r… ~41.3s    
#>  9 note    1.0     NN     117dcf5 6f7582d windows-x86_… ~1m       
#> 10 note    1.0     NN     117dcf5 9492a66 fedora-clang… ~45s      
#> # … with 41 more rows, and 6 more variables: submitted <dttm>,
#> #   started <dttm>, platform <list>, builder <chr>, status <rhub::status>,
#> #   email <chr>
# an ok result
rhub::get_check("1cbb7ff")$results_df()
#>   package version                submitted
#> 1  RLRsim   3.1-5 2019-04-25T12:56:45.577Z
#>                                platform
#> 1 linux-x86_64-rocker-gcc-san (r-devel)
# two notes
rhub::get_check("3c302fc")$results_df()
#>        type
#> notes1 NOTE
#> notes2 NOTE
#>                                                                                                                                                                                                                                                                                                   message
#> notes1 checking CRAN incoming feasibility ... NOTE\nMaintainer: ‘Maëlle Salmon <maelle.salmon@yahoo.se>’\n\nNew submission\n\nThe Description field contains\n  <http://http://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file>\nPlease enclose URLs in angle brackets (<...>).
#> notes2                                                                checking R code for possible problems ... NOTE\n.bello: no visible global function definition for ‘tail’\nUndefined global functions or variables:\n  tail\nConsider adding\n  importFrom("utils", "tail")\nto your NAMESPACE file.
#>                                    hash package version
#> notes1 f6a81a3b267893075828b3aecf56f409    note     1.0
#> notes2 e23a71da051ab63ef21ebaac3c43c2de    note     1.0
#>                       submitted                       platform
#> notes1 2019-03-27T15:03:34.772Z ubuntu-gcc-release (r-release)
#> notes2 2019-03-27T15:03:34.772Z ubuntu-gcc-release (r-release)
# a group of checks
rhub::get_check("4319312")$results_df()
#>        type
#> notes  NOTE
#> notes1 NOTE
#> notes2 NOTE
#>                                                                                                                                                                                                                          message
#> notes  checking CRAN incoming feasibility ... NOTE\nMaintainer: 'G�bor Cs�rdi <csardi.gabor@gmail.com>'\nNew maintainer:\nOld maintainer(s):\n  G�bor Cs�rdi <csardi.gabor@gmail.com>\n\n  Gabor Csardi <csardi.gabor@gmail.com>
#> notes1 checking CRAN incoming feasibility ... NOTE\nMaintainer: ‘Gábor Csárdi <csardi.gabor@gmail.com>’\n\nNew maintainer:\n  Gábor Csárdi <csardi.gabor@gmail.com>\nOld maintainer(s):\n  Gabor Csardi <csardi.gabor@gmail.com>
#> notes2 checking CRAN incoming feasibility ... NOTE\nMaintainer: ‘Gábor Csárdi <csardi.gabor@gmail.com>’\n\nNew maintainer:\n  Gábor Csárdi <csardi.gabor@gmail.com>\nOld maintainer(s):\n  Gabor Csardi <csardi.gabor@gmail.com>
#>                                    hash  package   version
#> notes  f6a81a3b267893075828b3aecf56f409 cranlogs 2.1.1.900
#> notes1 f6a81a3b267893075828b3aecf56f409 cranlogs 2.1.1.900
#> notes2 f6a81a3b267893075828b3aecf56f409 cranlogs 2.1.1.900
#>                       submitted                       platform
#> notes  2019-04-24T12:15:42.484Z windows-x86_64-devel (r-devel)
#> notes1 2019-04-24T12:15:42.484Z   fedora-clang-devel (r-devel)
#> notes2 2019-04-24T12:15:42.484Z ubuntu-gcc-release (r-release)
```

<sup>Created on 2019-04-25 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1)</sup>