### PR TITLE
fix typo in error msg

### DIFF
--- a/R/local.R
+++ b/R/local.R
@@ -41,8 +41,8 @@ local_check_linux <- function(path = ".", quiet = FALSE, image = NULL,
   assert_that(is_timeout(timeout <- as_timeout(timeout)))
   assert_that(is.character(artifacts))
 
-  if ((bash <- Sys.which("bash")) == "") {
-    stop("You need bash to run local Linux checks")
+  if ((bash <- Sys.which("bash")) == "" || Sys.which("docker") == "") {
+    stop("You need bash and Docker to run local Linux checks")
   }
 
   ## Build the tar.gz, if needed

--- a/R/local.R
+++ b/R/local.R
@@ -42,7 +42,7 @@ local_check_linux <- function(path = ".", quiet = FALSE, image = NULL,
   assert_that(is.character(artifacts))
 
   if ((bash <- Sys.which("bash")) == "") {
-    stop("You need bash, and Docker run local Linux checks")
+    stop("You need bash to run local Linux checks")
   }
 
   ## Build the tar.gz, if needed


### PR DESCRIPTION
not sure about the docker part; the assertion doesn't actually test that at that point, so users might find that error message confusing.

If I understand correctly, the availability of docker gets tested in `rhub-linux.sh`.