### PR TITLE
Installing Bioconductor for R >= 3.6.0

### DIFF
--- a/inst/bin/rhub-linux-docker.sh
+++ b/inst/bin/rhub-linux-docker.sh
@@ -38,8 +38,8 @@ config_all() {
     mkdir -p ~/R
     echo "options(repos = c(CRAN = \"$RHUB_CRAN_MIRROR\"))" >> ~/.Rprofile
     "$RBINARY" -q -e "if (getRversion() >= '3.6.0'){ install.packages('BiocManager'); BiocManager::install() } else { source('https://bioconductor.org/biocLite.R')}"
-    echo "options(repos = BiocInstaller::biocinstallRepos())" >> ~/.Rprofile
-    echo "unloadNamespace('BiocInstaller')" >> ~/.Rprofile
+    # echo "options(repos = BiocInstaller::biocinstallRepos())" >> ~/.Rprofile
+    # echo "unloadNamespace('BiocInstaller')" >> ~/.Rprofile
     cp "/tmp/${package}" .
 }
 

--- a/inst/bin/rhub-linux-docker.sh
+++ b/inst/bin/rhub-linux-docker.sh
@@ -37,7 +37,7 @@ config_all() {
     export R_LIBS=~/R
     mkdir -p ~/R
     echo "options(repos = c(CRAN = \"$RHUB_CRAN_MIRROR\"))" >> ~/.Rprofile
-    "$RBINARY" -q -e "source('https://bioconductor.org/biocLite.R')"
+    "$RBINARY" -q -e "if (getRversion() >= '3.6.0'){ install.packages('BiocManager'); BiocManager::install() } else { source('https://bioconductor.org/biocLite.R')}"
     echo "options(repos = BiocInstaller::biocinstallRepos())" >> ~/.Rprofile
     echo "unloadNamespace('BiocInstaller')" >> ~/.Rprofile
     cp "/tmp/${package}" .


### PR DESCRIPTION
because [biocLite]()https://bioconductor.org/biocLite.R) now has: 

```r
if (vers >= "3.6"){
        stop(
            "With R version 3.5 or greater, install Bioconductor ",
            "packages using BiocManager; see https://bioconductor.org/install",
            call. = FALSE
        )
    }
```

I'm not sure how to set the repos, hence the commented lines: 

```
    # echo "options(repos = BiocInstaller::biocinstallRepos())" >> ~/.Rprofile
    # echo "unloadNamespace('BiocInstaller')" >> ~/.Rprofile
```

This probably fixes https://github.com/r-hub/rhub-linux-builders/issues/42 