### PR TITLE
Update documentation in check-cran.R

### DIFF
--- a/R/check-cran.R
+++ b/R/check-cran.R
@@ -15,9 +15,9 @@
 #'
 #' @param check_args Arguments for `R CMD check`. By default `--as-cran`
 #'   is used.
-#' @param env_vars Environment variables to set on the builder. By default
-#'   `_R_CHECK_FORCE_SUGGESTS_=true` is set, to require all packages used.
-#'   `_R_CHECK_CRAN_INCOMING_USE_ASPELL_=true` is also set, to use the
+#' @param env_vars Character vecctor of environment variables to set on the builder. 
+#'   By default `_R_CHECK_FORCE_SUGGESTS_="true"` is set, to require all packages used.
+#'   `_R_CHECK_CRAN_INCOMING_USE_ASPELL_="true"` is also set, to use the
 #'   spell checker.
 #' @param platforms Character vector of platform ids to use
 #'   (see [platforms()]), or `NULL`. If `NULL`, then a set of default


### PR DESCRIPTION
The function at the top does not match the parameter descriptions, because the `"true"` must  be in quotation marks (not shown in the @param text).   If you want I can regenerate the man file, but I thought I would wait until you say what you think about the proposed change.   I also specified that it is a character
vector because I think when you have true and false people like me expect a logical.