### PR TITLE
Evaluate email file location at render time, not earlier.

### DIFF
--- a/R/email.R
+++ b/R/email.R
@@ -8,7 +8,7 @@
 #' The `rhub` package stores validated email addresses in a user
 #' configuration file, at a platform-dependent location.
 #' On your current platform the file is at
-#' \Sexpr{rhub:::email_file()}.
+#' \Sexpr[stage=render]{rhub:::email_file()}.
 #'
 #' To validate a new email address, call this function from an interactive
 #' R session, without any arguments.

--- a/man/validate_email.Rd
+++ b/man/validate_email.Rd
@@ -20,7 +20,7 @@ results.
 The \code{rhub} package stores validated email addresses in a user
 configuration file, at a platform-dependent location.
 On your current platform the file is at
-\Sexpr{rhub:::email_file()}.
+\Sexpr[stage=render]{rhub:::email_file()}.
 
 To validate a new email address, call this function from an interactive
 R session, without any arguments.
@@ -30,6 +30,7 @@ machine), to the configuration file, call this function with the \code{email}
 and \code{token} arguments.
 }
 \seealso{
-Other email validation: \code{\link{list_validated_emails}}
+Other email validation: 
+\code{\link{list_validated_emails}()}
 }
 \concept{email validation}


### PR DESCRIPTION
Users who install binaries of the package (e.g. on Windows or macOS) will see the email file location on the builder machine by default.  This evaluates it at the time the help page is rendered instead.