### PR TITLE
Fix biocmanager + devel for local builds

### DIFF
--- a/inst/bin/rhub-linux-docker.sh
+++ b/inst/bin/rhub-linux-docker.sh
@@ -38,7 +38,7 @@ config_all() {
     mkdir -p ~/R
     echo "options(repos = c(CRAN = \"$RHUB_CRAN_MIRROR\"))" >> ~/.Rprofile
     "$RBINARY" -q -e "install.packages('BiocManager')"
-    echo "options(repos = BiocManager::repositories())" >> ~/.Rprofile
+    echo "try(options(repos = BiocManager::repositories()))" >> ~/.Rprofile
     echo "unloadNamespace('BiocManager')" >> ~/.Rprofile
     cp "/tmp/${package}" .
 }


### PR DESCRIPTION
This is the same fix that was reported + fixed for hosted r-hub in #462. There are still warnings about the incompatibility, but a package that doesn't have bioc dependencies will continue on.
