### PR TITLE
Build message with paste0 to avoid extra spaces

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -90,11 +90,11 @@ assert_validated_email_for_check <- function(email) {
   if (is.null(code)) {
     if (is_interactive()) {
       cat("\n")
-      message(paste(collapse = "\n", strwrap(indent = 2, exdent = 2, paste(
-        sQuote(crayon::green(email)), "is not validated, or does not match",
-         "the package maintainer's email. To validate it now, please enter",
-        "the email address below. Note that R-hub will send a token to",
-        "this address. If the address does not belong to you, quit now by",
+      message(paste(collapse = "\n", strwrap(indent = 2, exdent = 2, paste0(
+        sQuote(crayon::green(email)), " is not validated, or does not match ",
+        "the package maintainer's email. To validate it now, please enter ",
+        "the email address below. Note that R-hub will send a token to ",
+        "this address. If the address does not belong to you, quit now by ",
         "pressing ", crayon::yellow("ENTER"), "."
       ))))
       cat("\n")


### PR DESCRIPTION
Current message display for me:

```
  ‘xxx’ is not validated, or does not match the package
  maintainer's email. To validate it now, please enter the email
  address below. Note that R-hub will send a token to this address. If
  the address does not belong to you, quit now by pressing
  ENTER .
```

The space after `ENTER` can't be build with `paste()`, so we should switch to `paste0()`.